### PR TITLE
Added invoke command for vanilla example

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,14 @@ fn main() {
     .expect("error while running tauri application")
 }
 ```
+
+To invoke a custom command from your own or remote system you can use `curl` or similar tooling.
+See [`examples/vanilla`](examples/vanilla/) to test this on your system.
+
+An example command to invoke the `exit` command in the example Tauri app exposing port `18436` (randomly chosen port) could look like:
+
+```sh
+curl localhost:18436/main -H 'Content-Type: application/json' -d '{ "__tauriModule": "Process", "cmd": "exit", "callback": 1234, "error": 1234, "message": {"cmd": "exit", "exitCode": 1  } }'
+```
+
+

--- a/examples/vanilla/src-tauri/src/main.rs
+++ b/examples/vanilla/src-tauri/src/main.rs
@@ -10,11 +10,9 @@ fn my_command(args: u64) -> Result<String, ()> {
 }
 
 fn main() {
-  let http = tauri_invoke_http::Invoke::new(if cfg!(feature = "custom-protocol") {
-    if cfg!(windows) { ["https://tauri.localhost"] } else { ["tauri://localhost"] }
-  } else {
-    ["http://127.0.0.1:1430"]
-  });
+  /// Allow from all origins for testing purposes. 
+  /// Should be allow listed to reduce risks of accidential exposure to other networks.
+  let http = tauri_invoke_http::Invoke::new(["*"]});
   tauri::Builder::default()
     .invoke_system(http.initialization_script(), http.responder())
     .setup(move |app| {

--- a/examples/vanilla/src-tauri/tauri.conf.json
+++ b/examples/vanilla/src-tauri/tauri.conf.json
@@ -29,7 +29,9 @@
       "active": false
     },
     "allowlist": {
-      "all": false
+      "process" : {
+        "exit" : true
+      }
     },
     "windows": [
       {


### PR DESCRIPTION
This PR adds an example command for the vanilla app, so it is simple to debug and test the functionality.
The `vanilla` example is now allowing messages from every origin, to simplify `cors` setup on local network tests
and exposes the `exit` endpoint from the Tauri `process` api.