### PR TITLE
fix an issue with allowed origin 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3121,7 +3121,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-invoke-http"
-version = "2.0.0-rc.0"
+version = "2.0.0-rc.1"
 dependencies = [
  "anyhow",
  "http-body-util",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ impl Cors for ResponseBuilder {
       );
     } else if let Some((_, origin)) = request_headers
       .iter()
-      .find(|(name, _value)| name.as_str() == "Origin")
+      .find(|(name, _value)| name.as_str().eq_ignore_ascii_case("origin"))
     {
       if allowed_origins
         .iter()


### PR DESCRIPTION
the CORS implementation is looking for a header named "Origin" (with capital O), but the header iterator is returning header names in lowercase.